### PR TITLE
Use android build-tools 26.0.3 and set compileSdkVersion and targetSd…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
React native's 0.56 release bumps android's sdk build tools to version 26.0.3, setting the minimum required version to 25.0.0.  