### PR TITLE
Use WebView from react-native-webview as it has been deprecated from …

### DIFF
--- a/iosWebView.js
+++ b/iosWebView.js
@@ -1,3 +1,3 @@
-import { WebView } from 'react-native';
+import WebView from "react-native-webview";
 
 export default WebView;

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/teamairship/react-native-android-fullscreen-webview-video/issues"
   },
-  "homepage": "https://github.com/teamairship/react-native-android-fullscreen-webview-video#readme"
+  "homepage": "https://github.com/teamairship/react-native-android-fullscreen-webview-video#readme",
+  "dependencies": {
+    "react-native-webview": "^5.2.1"
+  }
 }


### PR DESCRIPTION
Use WebView from react-native-webview as it has been deprecated from react-native and will be removed in future release.

See https://facebook.github.io/react-native/docs/webview for more info.